### PR TITLE
Fixed a bug in ConfideMongoUser.php

### DIFF
--- a/src/Zizaco/ConfideMongo/ConfideMongoUser.php
+++ b/src/Zizaco/ConfideMongo/ConfideMongoUser.php
@@ -177,7 +177,7 @@ class ConfideMongoUser extends MongoLid implements UserInterface {
     {
         $this->beforeSave($force);
 
-        $result = parent::save();
+        $result = parent::save($force);
 
         $this->afterSave($result, $force);
 


### PR DESCRIPTION
Force to save a user without validation was not working due to not passing $force to parent function call in 'save' function
