### PR TITLE
Implements abstract method validate(..)

### DIFF
--- a/src/Zizaco/ConfideMongo/ConfideMongoRepository.php
+++ b/src/Zizaco/ConfideMongo/ConfideMongoRepository.php
@@ -274,4 +274,9 @@ class ConfideMongoRepository implements ConfideRepository
 
         return $database;
     }
+    
+     public function validate(array $rules = array(), array $customMessages = array())
+    {
+        return $this->model()->validate($rules, $customMessages);
+    }
 }


### PR DESCRIPTION
Fix. I added implements method validate() in ConfideMongoRepository (?)

Is it okay ?

Symfony \ Component \ Debug \ Exception \ FatalErrorException

Class Zizaco\ConfideMongo\ConfideMongoRepository contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Zizaco\Confide\ConfideRepository::validate)
