### PR TITLE
Leave MongoDB extension requirement to Mongolid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "ext-mongo": "*",
         "illuminate/support": "5.*",
         "zizaco/mongolid-laravel": "*",
         "zizaco/confide": "5.0.x-dev"


### PR DESCRIPTION
We must remove the old mongo extension requirement in order to use in newest version with PHP 7 support.
